### PR TITLE
Removing API Keys from Client-Side using Serverless Functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .next/*
 .next/
 .env
+.vercel

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ npm install
 yarn install
 ```
 
+## Setting Up Environment Variables
+
+Before you build and run the project, you need to set up environment variables for the RPC URLs. Create a `.env.local` file in the root directory of your project and add the following lines:
+
+```bash
+NEXT_PUBLIC_DEVNET_RPC=https://devnet.helius-rpc.com/?api-key=YOUR_DEVNET_API_KEY
+NEXT_PUBLIC_MAINNET_RPC=https://rpc.helius.xyz/?api-key=YOUR_MAINNET_API_KEY
+```
+
+To prevent API keys from being exposed on the client-side, we utilize serverless functions in Next.js. These functions, housed in the `pages/api` directory, handle API calls server-side, ensuring the API keys, stored in environment variables, are never revealed to the client.
+
 ## Build and Run
 
 Next, run the development server:

--- a/src/pages/api/fetchManifest.ts
+++ b/src/pages/api/fetchManifest.ts
@@ -1,5 +1,5 @@
-import type { NextApiRequest, NextApiResponse } from 'next'
-import { clusterApiUrl } from '@solana/web3.js';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { clusterApiUrl, Cluster } from '@solana/web3.js';
 
 type ResponseData = {
   data: any;
@@ -12,10 +12,16 @@ export default async function handler(
 ) {
   try {
     const { network, publicKey } = req.query;
-    const apiURL = 
-      network === 'devnet' ? process.env.NEXT_PUBLIC_DEVNET_RPC :
-      network === 'mainnet-beta' ? process.env.NEXT_PUBLIC_MAINNET_RPC :
-      clusterApiUrl(network as string);
+    
+    const clusterMapping: { [key: string]: Cluster } = {
+        'devnet': 'devnet',
+        'mainnet-beta': 'mainnet-beta',
+      };
+      
+      const apiURL = 
+        network === 'devnet' ? process.env.NEXT_PUBLIC_DEVNET_RPC :
+        network === 'mainnet-beta' ? process.env.NEXT_PUBLIC_MAINNET_RPC :
+        clusterApiUrl(clusterMapping[network as string]);
 
     const response = await fetch(`${apiURL}?publicKey=${publicKey}`, {
       headers: {

--- a/src/pages/api/fetchManifest.ts
+++ b/src/pages/api/fetchManifest.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { clusterApiUrl, Cluster } from '@solana/web3.js';
 
 type ResponseData = {
-  data: any;
+  data?: any;
   error?: string;
 };
 
@@ -18,10 +18,10 @@ export default async function handler(
         'mainnet-beta': 'mainnet-beta',
       };
       
-      const apiURL = 
-        network === 'devnet' ? process.env.NEXT_PUBLIC_DEVNET_RPC :
-        network === 'mainnet-beta' ? process.env.NEXT_PUBLIC_MAINNET_RPC :
-        clusterApiUrl(clusterMapping[network as string]);
+    const apiURL = 
+      network === 'devnet' ? process.env.NEXT_PUBLIC_DEVNET_RPC :
+      network === 'mainnet-beta' ? process.env.NEXT_PUBLIC_MAINNET_RPC :
+      clusterApiUrl(clusterMapping[network as string]);
 
     const response = await fetch(`${apiURL}?publicKey=${publicKey}`, {
       headers: {

--- a/src/pages/api/fetchManifest.ts
+++ b/src/pages/api/fetchManifest.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { clusterApiUrl } from '@solana/web3.js';
+
+type ResponseData = {
+  data: any;
+  error?: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  try {
+    const { network, publicKey } = req.query;
+    const apiURL = 
+      network === 'devnet' ? process.env.NEXT_PUBLIC_DEVNET_RPC :
+      network === 'mainnet-beta' ? process.env.NEXT_PUBLIC_MAINNET_RPC :
+      clusterApiUrl(network as string);
+
+    const response = await fetch(`${apiURL}?publicKey=${publicKey}`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    const data = await response.json();
+    res.status(200).json({ data });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};

--- a/src/pages/api/fetchManifest.ts
+++ b/src/pages/api/fetchManifest.ts
@@ -1,36 +1,46 @@
+// Importing necessary types from Next.js and Solana's web3.js library
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { clusterApiUrl, Cluster } from '@solana/web3.js';
 
+// Defining a TypeScript type for the response data which can have either data or an error string
 type ResponseData = {
   data?: any;
   error?: string;
 };
 
+// Exporting the default async function handler which takes NextApiRequest and NextApiResponse with ResponseData type as parameters
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ResponseData>
 ) {
   try {
+    // Destructuring network and publicKey from the request query
     const { network, publicKey } = req.query;
     
+    // Mapping string keys to Cluster type to define network clusters
     const clusterMapping: { [key: string]: Cluster } = {
         'devnet': 'devnet',
         'mainnet-beta': 'mainnet-beta',
       };
       
+    // Determining the API URL based on the network type and fetching it from environment variables or using clusterApiUrl function
     const apiURL = 
       network === 'devnet' ? process.env.NEXT_PUBLIC_DEVNET_RPC :
       network === 'mainnet-beta' ? process.env.NEXT_PUBLIC_MAINNET_RPC :
       clusterApiUrl(clusterMapping[network as string]);
 
+    // Making a fetch request to the determined API URL with the publicKey as a query parameter
     const response = await fetch(`${apiURL}?publicKey=${publicKey}`, {
       headers: {
         'Content-Type': 'application/json',
       },
     });
+    // Parsing the response data to JSON
     const data = await response.json();
+    // Sending a successful response with the data
     res.status(200).json({ data });
   } catch (error) {
+    // Catching any errors and sending a 500 status code with the error message
     res.status(500).json({ error: error.message });
   }
 };

--- a/src/views/basics/index.tsx
+++ b/src/views/basics/index.tsx
@@ -8,7 +8,6 @@ import { DefaultInfo } from "components/DefaultInfo";
 import { PlaceLimitOrder } from "components/LimitOrder";
 import { FundingTrader } from "components/FundingTrg";
 import { ProductPrices } from "components/ProductPrices";
-import { PublicKey, clusterApiUrl } from "@solana/web3.js";
 import { AccountInfo } from "components/AccountInfo";
 import { PlaceMarketOrder } from "components/MarketOrder";
 import { OpenOrders } from "components/OpenOrders";
@@ -31,11 +30,7 @@ export const BasicsView: FC = ({ }) => {
       signAllTransactions,
     }
     console.log({ DexWallet })
-    const rpc =
-      network == 'devnet' ? process.env.NEXT_PUBLIC_DEVNET_RPC! :
-        network == 'mainnet-beta' ? process.env.NEXT_PUBLIC_MAINNET_RPC! :
-          clusterApiUrl(network)
-    const manifest = await dexterity.getManifest(rpc, true, DexWallet);
+    const manifest = await dexterity.getManifest(`/api/fetchManifest?network=${network}&publicKey=${publicKey}`, true, DexWallet);
     console.log('Manifest: ', manifest)
     setManifest(manifest);
   }, [publicKey]);


### PR DESCRIPTION
Transitioned the handling of API keys away from the client-side by utilizing Next.js serverless functions. 

Changes:

1. Introduced a serverless function in the pages/api directory to manage API calls server-side, ensuring the API keys are not accessible from the client-side.

2. Updated the README file about env variables 